### PR TITLE
Improve readme - Better to have the bash commands in a single line

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,7 +188,13 @@ For the calibration do the following steps:
 
 1. place the ArUco marker (on smobex_bringup/launch/bringup.launch put the correct marker id and size)
 
-2. run `roslaunch smobex_bringup bringup.launch calibration:=true`. If Rviz xtion Robot Description gives error state because of links from the robot, just press the Reset button. Don't know why this happens, but solves it...
+2. run 
+
+```bash 
+`roslaunch smobex_bringup bringup.launch calibration:=true`
+```
+
+If Rviz xtion Robot Description gives error state because of links from the robot, just press the Reset button. Don't know why this happens, but solves it...
 
 3. to store the calibration, open another terminal and run `rosrun smobex_calibration store_calibration.py` (thanks to @miguelriemoliveira for the source code).
 


### PR DESCRIPTION
i @joao-pm-santos96 , If you have bash commands in a single line you may just click three times on top to select the complete bash command. 
If the command is mixed with teh text this is not possible, so always use a separate line for the bash commands ...

Check [rustbot](https://github.com/miguelriemoliveira/RustBot) for an exemple of a Readme.md.